### PR TITLE
Add Peering Beacon Nodes to the devnet

### DIFF
--- a/Dockerfile.prysm
+++ b/Dockerfile.prysm
@@ -8,8 +8,13 @@ RUN go build -o /build/beacon-node -buildvcs=false ./cmd/beacon-chain
 RUN go build -o /build/validator -buildvcs=false ./cmd/validator
 
 FROM ubuntu:20.04
+RUN apt-get update && apt-get install -y curl jq
+
 COPY --from=builder /build/beacon-node /usr/local/bin/
 COPY --from=builder /build/validator /usr/local/bin/
 
+COPY run_beacon_node.sh /usr/local/bin/
+COPY run_beacon_node_peer.sh /usr/local/bin/
+
 WORKDIR /usr/local/bin
-EXPOSE 3500 4000
+EXPOSE 3500 4000 13000 12000 8080

--- a/Makefile
+++ b/Makefile
@@ -1,5 +1,5 @@
 devnet-up:
-	docker-compose up -d execution-node beacon-node validator-node jaeger-tracing
+	docker-compose up -d execution-node beacon-node beacon-node-follower validator-node jaeger-tracing
 
 devnet-clean:
 	docker-compose down

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -2,7 +2,8 @@ version: '3.4'
 
 volumes:
   geth_data:
-  validator_data:
+  beacon_node_data:
+  beacon_node_follower_data:
 
 services:
   execution-node:
@@ -22,34 +23,40 @@ services:
     build:
       context: .
       dockerfile: ./Dockerfile.prysm
+    environment:
+      EXECUTION_NODE_URL: http://execution-node:8545
+      TRACING_ENDPOINT: http://jaeger-tracing:14268/api/traces
+      PROCESS_NAME: beacon-node
+      VERBOSITY: debug
     command: >
-      beacon-node
-      --accept-terms-of-use
-      --datadir /chaindata
-      --force-clear-db
-      --interop-eth1data-votes
-      --min-sync-peers=0
-      --http-web3provider=http://execution-node:8545
-      --deposit-contract 0x8A04d14125D0FDCDc742F4A05C051De07232EDa4
-      --bootstrap-node=
-      --chain-config-file=/config/prysm-chain-config.yml
-      --disable-sync
-      --contract-deployment-block 0
-      --interop-num-validators 4
-      --rpc-host 0.0.0.0
-      --rpc-port 4000
-      --grpc-gateway-host 0.0.0.0
-      --grpc-gateway-port 3500
-      --enable-debug-rpc-endpoints
-      --enable-tracing
-      --tracing-endpoint http://jaeger-tracing:14268/api/traces
-      --tracing-process-name beacon-node
-      --verbosity debug
+      run_beacon_node.sh --min-sync-peers=0
     ports:
       - "3500:3500"
       - "4000:4000"
     volumes:
-      - "validator_data:/chaindata"
+      - "beacon_node_data:/chaindata"
+      - ${PWD}/prysm-chain-config.yml:/config/prysm-chain-config.yml
+
+  beacon-node-follower:
+    depends_on:
+      - execution-node
+      - beacon-node
+      - jaeger-tracing
+    build:
+      context: .
+      dockerfile: ./Dockerfile.prysm
+    environment:
+      EXECUTION_NODE_URL: http://execution-node:8545
+      TRACING_ENDPOINT: http://jaeger-tracing:14268/api/traces
+      PROCESS_NAME: beacon-node-follower
+      BEACON_NODE_RPC: http://beacon-node:3500
+      VERBOSITY: debug
+    command: run_beacon_node_peer.sh
+    ports:
+      - "3501:3500"
+      - "4001:4000"
+    volumes:
+      - "beacon_node_follower_data:/chaindata"
       - ${PWD}/prysm-chain-config.yml:/config/prysm-chain-config.yml
 
   validator-node:

--- a/run_beacon_node.sh
+++ b/run_beacon_node.sh
@@ -1,0 +1,30 @@
+#!/bin/env bash
+
+set -exu
+
+: "${EXECUTION_NODE_URL:-}"
+: "${PROCESS_NAME:-beacon-node}"
+: "${TRACING_ENDPOINT:-}"
+: "${VERBOSITY:-info}"
+
+beacon-node \
+    --accept-terms-of-use \
+    --verbosity="$VERBOSITY" \
+    --datadir /chaindata \
+    --force-clear-db \
+    --interop-eth1data-votes \
+    --http-web3provider="$EXECUTION_NODE_URL" \
+    --deposit-contract 0x8A04d14125D0FDCDc742F4A05C051De07232EDa4 \
+    --bootstrap-node= \
+    --chain-config-file=/config/prysm-chain-config.yml \
+    --disable-sync \
+    --contract-deployment-block 0 \
+    --interop-num-validators 4 \
+    --rpc-host 0.0.0.0 \
+    --rpc-port 4000 \
+    --grpc-gateway-host 0.0.0.0 \
+    --grpc-gateway-port 3500 \
+    --enable-debug-rpc-endpoints \
+    --enable-tracing \
+    --tracing-endpoint "$TRACING_ENDPOINT" \
+    --tracing-process-name "$PROCESS_NAME" $@

--- a/run_beacon_node_peer.sh
+++ b/run_beacon_node_peer.sh
@@ -1,0 +1,24 @@
+#!/bin/env bash
+
+set -exu
+
+: "${BEACON_NODE_RPC:-}"
+
+# Give the primary beacon node a sec to boot up. TODO(inphi): this should be more robust
+sleep 3
+
+# Retrieve the multiaddr of the primary beacon node. We will sync blocks from this peer.
+eval PEER=$(curl --fail --silent "$BEACON_NODE_RPC"/eth/v1/node/identity | jq '.data.p2p_addresses[0]')
+
+# Retrieve the generated genesis time so we can follow the peer with matching state roots
+eval INTEROP_GENESIS_TIME=$(curl --fail --silent "$BEACON_NODE_RPC"/eth/v1/beacon/genesis | jq .data.genesis_time)
+
+if [ "$PEER" = "null" ]; then
+    echo "Unable to start beacon-node: Beacon Node address is unavailable via $BEACON_NODE_RPC}"
+    exit 1
+fi
+
+run_beacon_node.sh \
+    --min-sync-peers=1 \
+    --peer "$PEER" \
+    --interop-genesis-time "$INTEROP_GENESIS_TIME" $@


### PR DESCRIPTION
We add a new beacon Node that peers with a  "primary" beacon node
to sync beacon blocks. This new beacon node does not have validators
interacting with it. As such, it merely acts as a follower to a peer node.

- Updated prysm submodule to fix p2p sync bug