### PR TITLE
p2p syncing in local devnet

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -27,7 +27,9 @@ jobs:
       run: go run ./upload -before 10 -after 20 eth.png
     - name: Download blobs
       run: go run ./download -start 1 -count 100 -addr /ip4/0.0.0.0/tcp/13000 > output.png
+    - name: Download blobs from peer
+      run: go run ./download -start 1 -count 100 -addr /ip4/0.0.0.0/tcp/13001 > output2.png
     - name: List
       run: ls -l
     - name: Compare files
-      run: git diff --no-index eth.png output.png
+      run: git diff --no-index eth.png output.png && git diff --no-index eth.png output2.png

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -26,9 +26,9 @@ jobs:
     - name: Upload blobs
       run: go run ./upload -before 10 -after 20 eth.png
     - name: Download blobs
-      run: go run ./download -start 1 -count 100 -addr /ip4/0.0.0.0/tcp/13000 > output.png
+      run: go run ./download -start 1 -count 200 -addr /ip4/0.0.0.0/tcp/13000 > output.png
     - name: Download blobs from peer
-      run: go run ./download -start 1 -count 100 -addr /ip4/0.0.0.0/tcp/13001 > output2.png
+      run: go run ./download -start 1 -count 200 -addr /ip4/0.0.0.0/tcp/13001 > output2.png
     - name: List
       run: ls -l
     - name: Compare files

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -39,7 +39,7 @@ jobs:
       if: failure()
       uses: jwalton/gh-docker-logs@v1
       with:
-        images: eip4844-interop_beacon-node-follower, eip4844-interop_beacon-node, eip4844-interop_execution-node-2, eip4844-interop_execution-node, eip4844-interop_validator-node
+        images: 'eip4844-interop_beacon-node-follower,eip4844-interop_beacon-node,eip4844-interop_execution-node-2,eip4844-interop_execution-node,eip4844-interop_validator-node'
         dest: './logs'
 
     - name: Tar logs

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -23,13 +23,32 @@ jobs:
     - uses: actions/setup-go@v3
       with:
         go-version: '^1.18.0'
+
     - name: Upload blobs
       run: go run ./upload -before 10 -after 20 eth.png
     - name: Download blobs
-      run: go run ./download -start 1 -count 200 -addr /ip4/0.0.0.0/tcp/13000 > output.png
+      run: go run ./download -start 1 -count 100 -addr /ip4/0.0.0.0/tcp/13000 > output.png
     - name: Download blobs from peer
-      run: go run ./download -start 1 -count 200 -addr /ip4/0.0.0.0/tcp/13001 > output2.png
+      run: go run ./download -start 1 -count 100 -addr /ip4/0.0.0.0/tcp/13001 > output2.png
     - name: List
       run: ls -l
     - name: Compare files
       run: git diff --no-index eth.png output.png && git diff --no-index eth.png output2.png
+
+    - name: Collect docker logs on failure
+      if: failure()
+      uses: jwalton/gh-docker-logs@v1
+      with:
+        images: eip4844-interop_beacon-node-follower, eip4844-interop_beacon-node, eip4844-interop_execution-node-2, eip4844-interop_execution-node, eip4844-interop_validator-node
+        dest: './logs'
+
+    - name: Tar logs
+      if: failure()
+      run: tar cvzf ./logs.tgz ./logs
+
+    - name: Upload logs to GitHub
+      if: failure()
+      uses: actions/upload-artifact@master
+      with:
+          name: logs.tgz
+          path: ./logs.tgz

--- a/Dockerfile.geth
+++ b/Dockerfile.geth
@@ -12,13 +12,20 @@ RUN go build \
     -o build/bin/geth \
     ./cmd/geth
 
+RUN go build \
+    -ldflags "-extldflags -Wl,-z,stack-size=0x800000" \
+    -buildvcs=false \
+    -o build/bin/bootnode \
+    ./cmd/bootnode
+
 # Pull Geth into a second stage deploy alpine container
 FROM alpine:3.15
 
 RUN apk add --no-cache ca-certificates curl
 COPY --from=builder /app/go-ethereum/build/bin/geth /usr/local/bin/
+COPY --from=builder /app/go-ethereum/build/bin/bootnode /usr/local/bin/
 
 WORKDIR /usr/local/bin/
-EXPOSE 8545 8546 8547
+EXPOSE 8545 8546 8547 30303/udp
 COPY ./geth.sh /geth.sh
 ENTRYPOINT ["/bin/sh", "/geth.sh"]

--- a/Makefile
+++ b/Makefile
@@ -1,5 +1,11 @@
 devnet-up:
-	docker-compose up -d execution-node execution-node-2 beacon-node beacon-node-follower validator-node jaeger-tracing
+	docker-compose up -d\
+		execution-node\
+		execution-node-2\
+		beacon-node\
+		beacon-node-follower\
+		validator-node\
+		jaeger-tracing
 
 devnet-clean:
 	docker-compose down

--- a/Makefile
+++ b/Makefile
@@ -1,5 +1,5 @@
 devnet-up:
-	docker-compose up -d execution-node beacon-node beacon-node-follower validator-node jaeger-tracing
+	docker-compose up -d execution-node execution-node-2 beacon-node beacon-node-follower validator-node jaeger-tracing
 
 devnet-clean:
 	docker-compose down

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -14,7 +14,7 @@ services:
     ports:
       - "8545:8545"
     environment:
-      GETH_VERBOSITY: 6
+      GETH_VERBOSITY: 4
     volumes:
       - "geth_data:/db"
       - type: bind
@@ -29,7 +29,7 @@ services:
       dockerfile: Dockerfile.geth
     environment:
       PEER: execution-node:30303
-      GETH_VERBOSITY: 6
+      GETH_VERBOSITY: 4
     ports:
       - "8546:8545"
     volumes:

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -2,6 +2,7 @@ version: '3.4'
 
 volumes:
   geth_data:
+  geth_data2:
   beacon_node_data:
   beacon_node_follower_data:
 
@@ -12,8 +13,27 @@ services:
       dockerfile: Dockerfile.geth
     ports:
       - "8545:8545"
+    environment:
+      GETH_VERBOSITY: 6
     volumes:
       - "geth_data:/db"
+      - type: bind
+        source: ./geth-genesis.json
+        target: /genesis.json
+
+  execution-node-2:
+    depends_on:
+      - execution-node
+    build:
+      context: .
+      dockerfile: Dockerfile.geth
+    environment:
+      PEER: execution-node:30303
+      GETH_VERBOSITY: 6
+    ports:
+      - "8546:8545"
+    volumes:
+      - "geth_data2:/db"
       - type: bind
         source: ./geth-genesis.json
         target: /genesis.json

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -51,7 +51,7 @@ services:
       PROCESS_NAME: beacon-node
       VERBOSITY: debug
     command: >
-      run_beacon_node.sh --min-sync-peers=0
+      run_beacon_node.sh --min-sync-peers=0 --disable-sync
     ports:
       - "3500:3500"
       - "4000:4000"
@@ -64,14 +64,14 @@ services:
 
   beacon-node-follower:
     depends_on:
-      - execution-node
+      - execution-node-2
       - beacon-node
       - jaeger-tracing
     build:
       context: .
       dockerfile: ./Dockerfile.prysm
     environment:
-      EXECUTION_NODE_URL: http://execution-node:8545
+      EXECUTION_NODE_URL: http://execution-node-2:8545
       TRACING_ENDPOINT: http://jaeger-tracing:14268/api/traces
       PROCESS_NAME: beacon-node-follower
       BEACON_NODE_RPC: http://beacon-node:3500

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -80,6 +80,7 @@ services:
     ports:
       - "3501:3500"
       - "4001:4000"
+      - "13001:13000"
     volumes:
       - "beacon_node_follower_data:/chaindata"
       - type: bind

--- a/download/main.go
+++ b/download/main.go
@@ -6,6 +6,7 @@ import (
 	"flag"
 	"fmt"
 	"io"
+	"os"
 	"strings"
 
 	"github.com/Inphi/eip4844-interop/shared"
@@ -88,8 +89,7 @@ func main() {
 			}
 		}
 		data = data[:i+1]
-		fmt.Printf("found blob at slot %v\n", sidecar.BeaconBlockSlot)
-		//_, _ = os.Stdout.Write(data)
+		_, _ = os.Stdout.Write(data)
 
 		// stop after the first sidecar with blobs:
 		break

--- a/download/main.go
+++ b/download/main.go
@@ -6,7 +6,6 @@ import (
 	"flag"
 	"fmt"
 	"io"
-	"os"
 	"strings"
 
 	"github.com/Inphi/eip4844-interop/shared"
@@ -89,7 +88,8 @@ func main() {
 			}
 		}
 		data = data[:i+1]
-		_, _ = os.Stdout.Write(data)
+		fmt.Printf("found blob at slot %v\n", sidecar.BeaconBlockSlot)
+		//_, _ = os.Stdout.Write(data)
 
 		// stop after the first sidecar with blobs:
 		break

--- a/geth.sh
+++ b/geth.sh
@@ -42,12 +42,14 @@ fi
 # retrieve our public IP address for discovery
 EXTERNAL_IP=$(ip addr show eth0 | grep inet | awk '{ print $2 }' | cut -d '/' -f1)
 ADDITIONAL_FLAGS="--nodiscover --nodekeyhex ${BOOTNODE_KEY_HEX} --nat extip:${EXTERNAL_IP}"
+MINE=--mine
 
 if [ -n "$PEER" ]; then
     PEER_PUBKEY=$(bootnode -nodekeyhex "$BOOTNODE_KEY_HEX" -writeaddress)
     PEER_ENODE="enode://${PEER_PUBKEY}@${PEER}"
     echo "Configuring static node at ${PEER_ENODE}"
     ADDITIONAL_FLAGS="--bootnodes ${PEER_ENODE}"
+    MINE=
     # wait a bit for the peer to come online
     sleep 4
 fi
@@ -71,5 +73,4 @@ exec geth \
     --authrpc.jwtsecret=0x98ea6e4f216f2fb4b69fff9b3a44842c38686ca685f3f55dc48c5d3fb1107be4 \
     --allow-insecure-unlock \
     --password "${GETH_DATA_DIR}/password" \
-    --unlock "0xa94f5374fce5edbc8e2a8697c15331677e6ebf0b" \
-    --mine
+    --unlock "0xa94f5374fce5edbc8e2a8697c15331677e6ebf0b" $MINE

--- a/geth.sh
+++ b/geth.sh
@@ -1,6 +1,6 @@
 #!/bin/sh
 
-set -exu
+set -exu -o pipefail
 
 VERBOSITY=${GETH_VERBOSITY:-4}
 GETH_DATA_DIR=/db

--- a/geth.sh
+++ b/geth.sh
@@ -8,9 +8,14 @@ GETH_KEYSTORE_DIR="$GETH_DATA_DIR/keystore"
 GETH_CHAINDATA_DIR="$GETH_DATA_DIR/geth/chaindata"
 GENESIS_FILE_PATH="${GENESIS_FILE_PATH:-/genesis.json}"
 BLOCK_SIGNER_PRIVATE_KEY="45a915e4d060149eb4365960e6a7a45f334393093061116b197e3240065ff2d8"
-BLOCK_SIGNER_ADDRESS="0xa94f5374fce5edbc8e2a8697c15331677e6ebf0b"
+#BLOCK_SIGNER_ADDRESS="0xa94f5374fce5edbc8e2a8697c15331677e6ebf0b"
 RPC_PORT="${RPC_PORT:-8545}"
 WS_PORT="${WS_PORT:-8546}"
+BOOTNODE_KEY_HEX=${BOOTNODE_KEY_HEX:-65f77f40c167b52b5cc70fb33582aecbdcd81062dc1438df00a3099a07079204}
+NETWORKID=69
+ENABLE_MINING=true
+
+PEER=${PEER:-}
 
 if [ ! -d "$GETH_KEYSTORE_DIR" ]; then
     echo "$GETH_KEYSTORE_DIR missing, running account import"
@@ -33,9 +38,24 @@ else
     echo "$GETH_CHAINDATA_DIR exists"
 fi
 
+# by default: flags for the bootnode
+# retrieve our public IP address for discovery
+EXTERNAL_IP=$(ip addr show eth0 | grep inet | awk '{ print $2 }' | cut -d '/' -f1)
+ADDITIONAL_FLAGS="--nodiscover --nodekeyhex ${BOOTNODE_KEY_HEX} --nat extip:${EXTERNAL_IP}"
+
+if [ -n "$PEER" ]; then
+    PEER_PUBKEY=$(bootnode -nodekeyhex "$BOOTNODE_KEY_HEX" -writeaddress)
+    PEER_ENODE="enode://${PEER_PUBKEY}@${PEER}"
+    echo "Configuring static node at ${PEER_ENODE}"
+    ADDITIONAL_FLAGS="--bootnodes ${PEER_ENODE}"
+    # wait a bit for the peer to come online
+    sleep 4
+fi
+
 exec geth \
-    --datadir ${GETH_DATA_DIR} \
-    --verbosity ${VERBOSITY} \
+    --datadir "$GETH_DATA_DIR" \
+    --verbosity "$VERBOSITY" \
+    --networkid "$NETWORKID" \
     --http \
     --http.corsdomain="*" \
     --http.vhosts="*" \
@@ -47,10 +67,9 @@ exec geth \
     --ws.port="$WS_PORT" \
     --ws.origins="*" \
     --ws.api=debug,eth,txpool,net,engine \
-    --allow-insecure-unlock \
-    --unlock "0xa94f5374fce5edbc8e2a8697c15331677e6ebf0b" \
-    --password ${GETH_DATA_DIR}/password \
-    --nodiscover \
-    --maxpeers=1 \
+    --maxpeers=2 ${ADDITIONAL_FLAGS} \
     --authrpc.jwtsecret=0x98ea6e4f216f2fb4b69fff9b3a44842c38686ca685f3f55dc48c5d3fb1107be4 \
+    --allow-insecure-unlock \
+    --password "${GETH_DATA_DIR}/password" \
+    --unlock "0xa94f5374fce5edbc8e2a8697c15331677e6ebf0b" \
     --mine

--- a/run_beacon_node.sh
+++ b/run_beacon_node.sh
@@ -1,11 +1,25 @@
 #!/bin/env bash
 
-set -exu
+set -exu -o pipefail
 
 : "${EXECUTION_NODE_URL:-}"
 : "${PROCESS_NAME:-beacon-node}"
 : "${TRACING_ENDPOINT:-}"
 : "${VERBOSITY:-info}"
+
+# wait for the execution node to start
+RETRIES=60
+i=0
+until curl --silent --fail "$EXECUTION_NODE_URL";
+do
+    sleep 1
+    if [ $i -eq $RETRIES ]; then
+        echo 'Timed out waiting for execution node'
+        exit 1
+    fi
+    echo 'Waiting for execution node...'
+    ((i=i+1))
+done
 
 beacon-node \
     --accept-terms-of-use \

--- a/run_beacon_node.sh
+++ b/run_beacon_node.sh
@@ -17,7 +17,6 @@ beacon-node \
     --deposit-contract 0x8A04d14125D0FDCDc742F4A05C051De07232EDa4 \
     --bootstrap-node= \
     --chain-config-file=/config/prysm-chain-config.yml \
-    --disable-sync \
     --contract-deployment-block 0 \
     --interop-num-validators 4 \
     --rpc-host 0.0.0.0 \

--- a/run_beacon_node_peer.sh
+++ b/run_beacon_node_peer.sh
@@ -1,17 +1,26 @@
 #!/bin/env bash
 
-set -exu
+set -exu -o pipefail
 
 : "${BEACON_NODE_RPC:-}"
 
-# Give the primary beacon node a sec to boot up. TODO(inphi): this should be more robust
-sleep 3
+# wait for the beacon node to start
+RETRIES=60
+i=0
+until curl --fail --silent "${BEACON_NODE_RPC}/eth/v1/node/health"; do
+    sleep 1
+    if [ $i -eq $RETRIES ]; then
+        echo "Timed out retrieving beacon node p2p addr"
+        exit 1
+    fi
+    echo "waiting for beacon node RPC..."
+    ((i=i+1))
+done
 
 # Retrieve the multiaddr of the primary beacon node. We will sync blocks from this peer.
-eval PEER=$(curl --fail --silent "$BEACON_NODE_RPC"/eth/v1/node/identity | jq '.data.p2p_addresses[0]')
-
+PEER=$(curl --fail "$BEACON_NODE_RPC"/eth/v1/node/identity | jq '.data.p2p_addresses[0]' | tr -d '"')
 # Retrieve the generated genesis time so we can follow the peer with matching state roots
-eval INTEROP_GENESIS_TIME=$(curl --fail --silent "$BEACON_NODE_RPC"/eth/v1/beacon/genesis | jq .data.genesis_time)
+INTEROP_GENESIS_TIME=$(curl --fail "$BEACON_NODE_RPC"/eth/v1/beacon/genesis | jq .data.genesis_time | tr -d '"')
 
 if [ "$PEER" = "null" ]; then
     echo "Unable to start beacon-node: Beacon Node address is unavailable via $BEACON_NODE_RPC}"

--- a/run_beacon_node_peer.sh
+++ b/run_beacon_node_peer.sh
@@ -18,6 +18,7 @@ if [ "$PEER" = "null" ]; then
     exit 1
 fi
 
+# TODO(inphi): Content Discovery using peer as bootstrap-node
 run_beacon_node.sh \
     --min-sync-peers=1 \
     --peer "$PEER" \

--- a/upload/main.go
+++ b/upload/main.go
@@ -99,7 +99,7 @@ func main() {
 		log.Fatalf("Error sending tx: %v", err)
 	}
 
-	log.Printf("Transaction submitted")
+	log.Printf("Transaction submitted. hash=%v", tx.Hash())
 
 	if *after > 0 {
 		waitForBlock(ctx, client, *after)


### PR DESCRIPTION
- Add a new execution-client DC service
- Setup p2p network between both execution clients.
- Configure the `beacon-node-follower` to connect to the new execution-client.
- Update go-ethereum submodule to fix blob sync