### PR TITLE
tweaks to build process

### DIFF
--- a/Dockerfile.geth
+++ b/Dockerfile.geth
@@ -5,6 +5,10 @@ RUN apk add --no-cache make gcc musl-dev linux-headers git
 COPY ./go-ethereum /app/go-ethereum
 
 WORKDIR /app/go-ethereum
+
+# The flag below may be needed if blst throws SIGILL, which happens with certain (older) CPUs
+# ENV CGO_CFLAGS="-O -D__BLST_PORTABLE__"
+
 # Build directly as make geth doesn't work because it expects a normal git repository rather than a submodule. We set -buildvcs directly here to avoid this
 RUN go build \
     -ldflags "-extldflags -Wl,-z,stack-size=0x800000" \

--- a/Dockerfile.prysm
+++ b/Dockerfile.prysm
@@ -4,6 +4,9 @@ COPY ./prysm /app/prysm
 
 WORKDIR /app/prysm
 
+# The flag below may be needed if blst throws SIGILL, which happens with certain (older) CPUs
+# ENV CGO_CFLAGS="-O -D__BLST_PORTABLE__"
+
 RUN go build -o /build/beacon-node -buildvcs=false ./cmd/beacon-chain
 RUN go build -o /build/validator -buildvcs=false ./cmd/validator
 

--- a/Makefile
+++ b/Makefile
@@ -1,5 +1,5 @@
 devnet-up:
-	docker-compose up -d\
+	docker compose up -d\
 		execution-node\
 		execution-node-2\
 		beacon-node\
@@ -8,13 +8,13 @@ devnet-up:
 		jaeger-tracing
 
 devnet-down:
-	docker-compose down -v
+	docker compose down -v
 
 devnet-restart: devnet-down devnet-up
 
 devnet-clean:
-	docker-compose down
-	docker image ls 'eip4844-interop*' --format='{{.Repository}}' | xargs docker rmi
-	docker volume ls --filter name=eip4844-interop --format='{{.Name}}' | xargs docker volume rm
+	docker compose down
+	docker image ls 'eip4844-interop*' --format='{{.Repository}}' | xargs -r docker rmi
+	docker volume ls --filter name=eip4844-interop --format='{{.Name}}' | xargs -r docker volume rm
 
 .PHONY: devnet-clean


### PR DESCRIPTION
1) added a ENV option in dockerfiles that can be uncommented to allow blst to work with older CPUs

2) changed "docker-compose" to "docker compose" which is the current recommended approach to invoking docker compose.

3) added -r to xargs so that make commands don't error out on an empty list