### PR TITLE
Silence Sync Committee message errors

### DIFF
--- a/run_beacon_node.sh
+++ b/run_beacon_node.sh
@@ -43,6 +43,7 @@ beacon-node \
     --p2p-local-ip 0.0.0.0 \
     --p2p-host-ip "$EXTERNAL_IP" \
     --p2p-priv-key="$P2P_PRIV_KEY"\
+    --subscribe-all-subnets \
     --enable-tracing \
     --tracing-endpoint "$TRACING_ENDPOINT" \
     --tracing-process-name "$PROCESS_NAME" $@


### PR DESCRIPTION
This gets rid of the numerous "unable to find requisite number of peers for topic /eth2/b206ff88/sync_committee_0/ssz_snappy - only 0 out of 1 peers were able to be found" errors in the beacon node.