### PR TITLE
make tests support both 'docker compose' and 'docker-compose'

### DIFF
--- a/tests/ctrl/ctrl.go
+++ b/tests/ctrl/ctrl.go
@@ -32,11 +32,19 @@ func Run(cmd *exec.Cmd) error {
 }
 
 func StartDevnet() error {
-	return Run(exec.Command("/bin/sh", "-c", "docker-compose up -d"))
+	err := Run(exec.Command("/bin/sh", "-c", "docker-compose up -d"))
+	if err != nil && err.(*exec.ExitError).ExitCode() == 127 {
+		err = Run(exec.Command("/bin/sh", "-c", "docker compose up -d"))
+	}
+	return err
 }
 
 func StopDevnet() error {
-	return Run(exec.Command("/bin/sh", "-c", "docker-compose down -v"))
+	err := Run(exec.Command("/bin/sh", "-c", "docker-compose down -v"))
+	if err != nil && err.(*exec.ExitError).ExitCode() == 127 {
+		err = Run(exec.Command("/bin/sh", "-c", "docker compose down -v"))
+	}
+	return err
 }
 
 func RestartDevnet() error {

--- a/tests/fee-market/main.go
+++ b/tests/fee-market/main.go
@@ -232,7 +232,7 @@ func UploadBlobsAndCheckBlockHeader(ctx context.Context, blobsData []types.Blobs
 		// Assuming each transaction contains a single blob
 		expected := misc.CalcExcessDataGas(prevExcessDataGas, len(block.Transactions()))
 		if expected.Cmp(block.ExcessDataGas()) != 0 {
-			log.Fatal("unexpected excess_data_gas field in header. expected %v. got %v", expected, block.ExcessDataGas())
+			log.Fatalf("unexpected excess_data_gas field in header. expected %v. got %v", expected, block.ExcessDataGas())
 		}
 		prevExcessDataGas = expected
 	}


### PR DESCRIPTION
Also fixes a log.Fatal that should have been Fatalf.
