### PR TITLE
Fix clean

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -1,5 +1,5 @@
 devnet-up:
-	docker compose up -d\
+	docker compose --project-name eip4844-interop up -d\
 		execution-node\
 		execution-node-2\
 		prysm-beacon-node\
@@ -8,7 +8,7 @@ devnet-up:
 		jaeger-tracing
 
 lodestar-up:
-	docker compose up -d\
+	docker compose --project-name eip4844-interop up -d\
 		execution-node\
 		execution-node-2\
 		lodestar-beacon-node\
@@ -21,7 +21,8 @@ devnet-restart: devnet-down devnet-up
 
 devnet-clean:
 	docker compose down
-	docker image ls 'interop*' --format='{{.Repository}}' | xargs -r docker rmi
-	docker volume ls --filter name=interop --format='{{.Name}}' | xargs -r docker volume rm
+	docker compose down --volumes
+	docker image ls 'eip4844-interop*' --format='{{.Repository}}' | xargs -r docker image rm -f
+	docker volume ls --filter name=eip4844-interop --format='{{.Name}}' | xargs -r docker volume rm -f
 
 .PHONY: devnet-clean

--- a/Makefile
+++ b/Makefile
@@ -1,5 +1,5 @@
 devnet-up:
-	docker compose --project-name eip4844-interop up -d\
+	docker compose up -d\
 		execution-node\
 		execution-node-2\
 		prysm-beacon-node\
@@ -8,7 +8,7 @@ devnet-up:
 		jaeger-tracing
 
 lodestar-up:
-	docker compose --project-name eip4844-interop up -d\
+	docker compose up -d\
 		execution-node\
 		execution-node-2\
 		lodestar-beacon-node\
@@ -20,9 +20,8 @@ devnet-down:
 devnet-restart: devnet-down devnet-up
 
 devnet-clean:
-	docker compose down
-	docker compose down --volumes
-	docker image ls 'eip4844-interop*' --format='{{.Repository}}' | xargs -r docker image rm -f
-	docker volume ls --filter name=eip4844-interop --format='{{.Name}}' | xargs -r docker volume rm -f
+	docker compose down --rmi local --volumes
+	docker image ls '`basename $PWD`-interop*' --format='{{.Repository}}' | xargs -r docker rmi
+	docker volume ls --filter name=`basename $PWD`-interop --format='{{.Name}}' | xargs -r docker volume rm
 
 .PHONY: devnet-clean

--- a/Makefile
+++ b/Makefile
@@ -1,5 +1,5 @@
 devnet-up:
-	docker compose up -d\
+	docker compose --project-name eip-4844 up -d\
 		execution-node\
 		execution-node-2\
 		prysm-beacon-node\
@@ -8,20 +8,20 @@ devnet-up:
 		jaeger-tracing
 
 lodestar-up:
-	docker compose up -d\
+	docker compose --project-name eip-4844 up -d\
 		execution-node\
 		execution-node-2\
 		lodestar-beacon-node\
 		lodestar-beacon-node-follower\
 
 devnet-down:
-	docker compose down -v
+	docker compose --project-name eip-4844 down -v
 
 devnet-restart: devnet-down devnet-up
 
 devnet-clean:
-	docker compose down --rmi local --volumes
-	docker image ls '`basename $PWD`-interop*' --format='{{.Repository}}' | xargs -r docker rmi
-	docker volume ls --filter name=`basename $PWD`-interop --format='{{.Name}}' | xargs -r docker volume rm
+	docker compose --project-name eip-4844 down --rmi local --volumes
+	docker image ls 'eip-4844-interop*' --format='{{.Repository}}' | xargs -r docker rmi
+	docker volume ls --filter name=eip-4844-interop --format='{{.Name}}' | xargs -r docker volume rm
 
 .PHONY: devnet-clean


### PR DESCRIPTION
Docker creates image names prefixed with the "project name" which defaults to the name of the current directory. If you check this repo out to a directory named something other than "eip-4844", the project name changes.

This PR make our `make` commands supply `docker compose` the `project-name` flag in all instances, so it's consistent and never inferred from the directory name.