### PR TITLE
Add docker layer caching to CI

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -24,6 +24,12 @@ jobs:
           #       go 1.19 is incompatible with the github.com/lucas-clemente/quic-go v0.27.2 dependency
           go-version: '1.18'
 
+      - uses: jpribyl/action-docker-layer-caching@v0.1.1
+        # Ignore the failure of a step and avoid terminating the job.
+        continue-on-error: true
+        with:
+          key: docker-cache-${{ hashFiles('.git/modules/prysm/*/HEAD', '.git/modules/geth/*/HEAD') }}
+
       - name: Prysm - Run pre-EIP4844 tests
         timeout-minutes: 30
         run: go run ./tests/pre-4844 prysm
@@ -71,6 +77,12 @@ jobs:
         with:
           #       go 1.19 is incompatible with the github.com/lucas-clemente/quic-go v0.27.2 dependency
           go-version: '1.18'
+
+      - uses: jpribyl/action-docker-layer-caching@v0.1.1
+        # Ignore the failure of a step and avoid terminating the job.
+        continue-on-error: true
+        with:
+          key: docker-cache-${{ hashFiles('.git/modules/lodestar/*/HEAD', '.git/modules/geth/*/HEAD') }}
 
       - name: Lodestar - Run pre-EIP4844 tests
         run: go run ./tests/pre-4844 lodestar

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -113,3 +113,4 @@ jobs:
         with:
           name: logs.tgz
           path: ./logs.tgz
+

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -113,4 +113,3 @@ jobs:
         with:
           name: logs.tgz
           path: ./logs.tgz
-


### PR DESCRIPTION
Addresses #30 

Looking at a small sample size of builds, it takes about 2.5 minutes to restore the cache, vs 7-8 mins to build without cache, the improvement is approx. 5 mins reduction in build time.

https://github.com/jimmygchen/eip4844-interop/actions/runs/3645681672/jobs/6156036845
https://github.com/jimmygchen/eip4844-interop/actions/runs/3645901401/jobs/6156469505

However, the current test times are quite long and fluctuate a lot, it seems to be a really small percentage of the overall build time... small improvement still 😄 

It would probably make a bigger difference when/if we switch over to minimal preset, given that `FIELD_ELEMENT_PER_BLOB` is now configurable in c-kzg.
