### PR TITLE
Use bazel for prysm docker builds

### DIFF
--- a/prysm/Dockerfile.prysm
+++ b/prysm/Dockerfile.prysm
@@ -1,28 +1,25 @@
 FROM golang:1.18 as builder
 
-COPY ./prysm/go.mod ./prysm/go.sum /app/prysm/
+RUN apt-get update
+
+RUN go install github.com/bazelbuild/bazelisk@latest
 
 WORKDIR /app/prysm
-
-RUN go mod download
 
 COPY ./prysm /app/prysm
-
-WORKDIR /app/prysm
 
 # The flag below may be needed if blst throws SIGILL, which happens with certain (older) CPUs
 # ENV CGO_CFLAGS="-O -D__BLST_PORTABLE__"
 ENV CGO_CFLAGS=$CGO_CFLAGS
 
-RUN go build -o /build/beacon-node -buildvcs=false ./cmd/beacon-chain
-RUN go build -o /build/validator -buildvcs=false ./cmd/validator
-RUN go build -o /build/bootnode -buildvcs=false ./tools/bootnode
+RUN apt-get install patch
+RUN bazelisk build //cmd/beacon-chain //cmd/validator
 
 FROM ubuntu:20.04
 RUN apt-get update && apt-get install -y curl jq iproute2
 
-COPY --from=builder /build/beacon-node /usr/local/bin/
-COPY --from=builder /build/validator /usr/local/bin/
+COPY --from=builder /app/prysm/bazel-out/k8-fastbuild/bin/cmd/beacon-chain/beacon-chain_/beacon-chain /usr/local/bin/
+COPY --from=builder /app/prysm/bazel-out/k8-fastbuild/bin/cmd/validator/validator_/validator /usr/local/bin/
 
 WORKDIR /usr/local/bin
 EXPOSE 3500 4000 7500 13000 12000 8080

--- a/prysm/run_beacon_node.sh
+++ b/prysm/run_beacon_node.sh
@@ -24,7 +24,7 @@ done
 
 EXTERNAL_IP=$(ip addr show eth0 | grep inet | awk '{ print $2 }' | cut -d '/' -f1)
 
-beacon-node \
+beacon-chain \
     --accept-terms-of-use \
     --verbosity="$VERBOSITY" \
     --datadir /chaindata \


### PR DESCRIPTION
The latest prysm can no longer be built directly using `go`.